### PR TITLE
Configurable account-id

### DIFF
--- a/app.go
+++ b/app.go
@@ -15,6 +15,7 @@ type App struct {
 	AppPort          string
 	Hostname         string
 	InstanceID       string
+	AccountID        string
 	InstanceType     string
 	MacAddress       string
 	PrivateIp        string
@@ -47,6 +48,7 @@ func (app *App) addFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&app.Hostname, "hostname", app.Hostname, "EC2 Instance Hostname")
 	fs.StringVar(&app.InstanceID, "instance-id", app.InstanceID, "EC2 Instance ID")
 	fs.StringVar(&app.InstanceType, "instance-type", app.InstanceType, "EC2 Instance Type")
+	fs.StringVar(&app.AccountID, "account-id", app.AccountID, "AWS Account ID")
 	fs.StringVar(&app.MacAddress, "mac-address", app.MacAddress, "ENI MAC Address")
 	fs.StringVar(&app.PrivateIp, "private-ip", app.PrivateIp, "ENI Private IP")
 	fs.BoolVar(&app.MockInstanceProfile, "mock-instance-profile", false, "Use mocked IAM Instance Profile credentials (instead of STS generated credentials)")

--- a/main_test.go
+++ b/main_test.go
@@ -21,6 +21,7 @@ func TestMain(m *testing.M) {
 	app.Hostname = "testhostname"
 	app.InstanceID = "i-asdfasdf"
 	app.InstanceType = "t2.micro"
+	app.AccountID = "123456789012"
 	app.MacAddress = "00:aa:bb:cc:dd:ee"
 	app.MockInstanceProfile = true
 	app.PrivateIp = "10.20.30.40"

--- a/server.go
+++ b/server.go
@@ -293,7 +293,7 @@ func (app *App) instanceIdentityDocumentHandler(w http.ResponseWriter, r *http.R
 		InstanceId:         app.InstanceID,
 		BillingProducts:    nil,
 		InstanceType:       app.InstanceType,
-		AccountId:          "123456789012",
+		AccountId:          app.AccountID,
 		ImageId:            app.AmiID,
 		PendingTime:        "2016-04-15T12:14:15Z",
 		Architecture:       "x86_64",


### PR DESCRIPTION
Configurable AWS Account ID.

Set:
```bash
$ ./aws-mock-metadata ... --account-id "123456789012"
```

Use:
```bash
curl http://169.254.169.254/latest/dynamic/instance-identity/document | jq -r .accountId
```