### PR TITLE
Remove build dependency on 'gometalinter' tool

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ build: *.go
 	gofmt -w=true .
 	go build -o bin/aws-mock-metadata $(GOBUILD_VERSION_ARGS) github.com/jtblin/aws-mock-metadata
 
-test: check
+test: build
 	go test
 
 junit-test: build


### PR DESCRIPTION
Doing this make building a simple matter of cloning and running `make docker`.