### PR TITLE
Feature - Add configurable network interface

### DIFF
--- a/app.go
+++ b/app.go
@@ -12,6 +12,7 @@ import (
 type App struct {
 	AmiID            string
 	AvailabilityZone string
+	AppInterface     string
 	AppPort          string
 	Hostname         string
 	InstanceID       string
@@ -44,6 +45,7 @@ func main() {
 func (app *App) addFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&app.AmiID, "ami-id", app.AmiID, "EC2 Instance AMI ID")
 	fs.StringVar(&app.AvailabilityZone, "availability-zone", app.AvailabilityZone, "Availability Zone")
+	fs.StringVar(&app.AppInterface, "app-interface", app.AppInterface, "HTTP Network Interface")
 	fs.StringVar(&app.AppPort, "app-port", app.AppPort, "HTTP Port")
 	fs.StringVar(&app.Hostname, "hostname", app.Hostname, "EC2 Instance Hostname")
 	fs.StringVar(&app.InstanceID, "instance-id", app.InstanceID, "EC2 Instance ID")

--- a/server.go
+++ b/server.go
@@ -18,8 +18,8 @@ import (
 
 // StartServer starts a newly created http server
 func (app *App) StartServer() {
-	log.Infof("Listening on port %s", app.AppPort)
-	if err := http.ListenAndServe(":"+app.AppPort, app.NewServer()); err != nil {
+	log.Infof("Listening on port %s:%s", app.AppInterface, app.AppPort)
+	if err := http.ListenAndServe(app.AppInterface+":"+app.AppPort, app.NewServer()); err != nil {
 		log.Fatalf("Error creating http server: %+v", err)
 	}
 }


### PR DESCRIPTION
This is useful when running with `host` netns and listening on `169.254.169.254`